### PR TITLE
Changes for Terraform 1.4.0

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,22 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.44.1"
-  constraints = ">= 2.83.0, >= 3.7.0, >= 3.26.0, >= 3.34.0, 3.44.1"
+  version     = "3.47.0"
+  constraints = ">= 2.83.0, >= 3.7.0, >= 3.26.0, >= 3.34.0, 3.47.0"
   hashes = [
-    "h1:dq7s/3sZrI4oLWL/NUlOcOD3HGkzimRmEvFiWX+ENRw=",
-    "zh:0a1761b5aeec47d5019114976de5eb9832dea1d57d632ca6fa464b99b782d1c1",
-    "zh:0e9c96fa7ed6d55a3f3a646ff346298c8b7728331bb3a74875f78ecb7d245c16",
-    "zh:1aa953a692c7b5b10219343f0238f4624ac988e247721b6ec6b1bed2b81f7ceb",
-    "zh:237258af1a1ce8a0aed8f6cdb03c69ea83ff4f3a46d5bd1466cd503f0b5aded8",
-    "zh:542067eeeb3b4e286e92d646e0f40426e204ed268973343e585aa521f075f8dc",
-    "zh:8326d52460252fd335ae97d0fabd9f5d90061a4fbeb273618f4067be3eb4e75a",
-    "zh:97a2b802bf6e204476131ddb7a91e832568ee8da3b0515ed23361c9f72ca9706",
-    "zh:9ae5a52ec85e0ad218e2ce9d33859f17afbb2fb2a690bf60d5f48fc7680e7fb0",
-    "zh:b17e77aff310e232f541334ba1858b5125ea0e527a5d6824de017192d8d8a3a2",
-    "zh:c469ba6681535c07c58dad6c1b59b056912300a7c91137ddc0103ef16b1d5697",
-    "zh:cea6026ef8fb5512d14c1ba6fdf36b90a09de536d4e4afad96b926af39114f74",
+    "h1:JW85JWb8IHUrf02p2ZA0bnfqbl/R6edKEke+1FnPbFA=",
+    "zh:099ffaec3ef0ef45a23aebd851fdf49a279f872632dd2e72fa3cb897621511ac",
+    "zh:0a2c33eff74c8934a371cff9647edc59a35cd2810d63613e5de4f6f2e43ae014",
+    "zh:0ac4934c8ebff2cdb5aba2728693ba8e2143f7a16f51dadaff5847a442d535b3",
+    "zh:125d2e039796ccf50f08e254be6f6258c28739fe28083c8e9fcb3952084bebb5",
+    "zh:39de12f00902dbe42a07b75687b9f4c2f141874bd8c0d544b02f23991e295f66",
+    "zh:584241a1dbee15d09007cfba5a341d0ae05722c194f51a67e01e4f6258dadc5e",
+    "zh:a0001c265faa25e3b3595fd530891cb08a01108cecea9b84289420a83e3d57dc",
+    "zh:c636316dc16226754b7c340fe0ad16fb1b2d9d4530303e9179be7205568cf40f",
+    "zh:ce6e92a57a5f277f9ccab2a119f939faa28ada04eb2cc9d3f2d2c70dc19a1a84",
+    "zh:cfde69b8c48edda6ac232d3afa676cfd9fa60515e43d764666a657b190b7ed71",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc1269b2f4d27cd2d14cd970e5b5066adf68a3b267f21d57edc36b8ef6dba82f",
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -154,12 +154,12 @@ terraform {
         access_key = "bRtDCEojOLE122v5glr8g+kyxLytWMp/OSPsjqmiXr972xPOGNRwXOBFPCCze1Ge5dk+imhW+ZdKeOFahNVEFg=="
     }
 
-    required_version = ">= 1.3.9"
+    required_version = ">= 1.4.0"
 
     required_providers {
         azurerm = {
             source  = "hashicorp/azurerm"
-            version = "3.44.1"
+            version = "3.47.0"
         }
         random = {
             source = "hashicorp/random"

--- a/uksouth/frontdoor_premium/acmebot.tf
+++ b/uksouth/frontdoor_premium/acmebot.tf
@@ -44,7 +44,7 @@ resource "azurerm_resource_group" "acmebot" {
 
 module "keyvault_acmebot" {
     source = "shibayan/keyvault-acmebot/azurerm"
-    version = "~> 2.1.0"
+    version = "~> 2.2.0"
 
     function_app_name = "bink-${azurerm_resource_group.acmebot.location}-acmebot"
     app_service_plan_name = "bink-${azurerm_resource_group.acmebot.location}-acmebot"
@@ -64,17 +64,16 @@ module "keyvault_acmebot" {
         var.common.secure_origins.ipv4, var.common.secure_origins.ipv6, var.common.secure_origins.checkly
     )
 
-    # TODO: Figure this out, has been manually configured in Portal, think module needs uplift
-    # auth_settings = {
-    #     enabled = true
-    #     issuer = "https://sts.windows.net/a6e2367a-92ea-4e5a-b565-723830bcc095/v2.0"
-    #     token_store_enabled = true
-    #     active_directory = {
-    #         client_id = "04e20ce8-bb3d-4237-9cd9-8ae4c3df7f15"
-    #         allowed_audiences = ["api://04e20ce8-bb3d-4237-9cd9-8ae4c3df7f15"]
-    #     }
-    #     unauthenticated_client_action = "RedirectToLoginPage"
-    # }
+    auth_settings_v2 = {
+        login = {
+            token_store_enabled = false
+        }
+        active_directory_v2 = {
+            client_id = "04e20ce8-bb3d-4237-9cd9-8ae4c3df7f15"
+            allowed_audiences = ["api://04e20ce8-bb3d-4237-9cd9-8ae4c3df7f15"]
+            tenant_auth_endpoint = "https://sts.windows.net/a6e2367a-92ea-4e5a-b565-723830bcc095/v2.0"
+        }
+    }
 }
 
 resource "azurerm_key_vault_access_policy" "acmebot" {


### PR DESCRIPTION
Do not merge until https://github.com/shibayan/terraform-azurerm-keyvault-acmebot/pull/45 has been merged and a new release has been cut.

https://github.com/binkhq/tf-azurerm/blob/tf_1.4.0/uksouth/frontdoor_premium/acmebot.tf#L47 may need to be modified to whatever the owned changes the version string to, `2.2.0` was a guess.