### PR TITLE
feat: add new auth0 custom domains

### DIFF
--- a/uksouth/firewall/rules.tf
+++ b/uksouth/firewall/rules.tf
@@ -347,7 +347,9 @@ resource "azurerm_firewall_application_rule_collection" "software" {
         source_addresses = ["*"]
         target_fqdns = [
             "bink.eu.auth0.com",
-            "auth.bink.com",
+            "auth.bink.com",            # currently used by the non-prod Auth0 tenant. deprecated.
+            "auth.nonprod.gb.bink.com"  # to be used by the non-prod Auth0 tenant.
+            "auth.gb.bink.com",         # to be used by the prod Auth0 tenant.
         ]
         protocol {
           port = "443"


### PR DESCRIPTION
these two new URLs (provisional - feel free to suggest changes) are to support the prod and non-prod Auth0 tenants.

i have left the existing URL in place so we don't immediately break the portal in dev & staging. it can be removed once the non-prod Auth0 tenant has been updated to use the new URL as its custom domain.